### PR TITLE
Fix inline styles open

### DIFF
--- a/coverage/html.py
+++ b/coverage/html.py
@@ -99,8 +99,8 @@ class HtmlReporter(Reporter):
             self.not_inline_styles = False
 
             # reading the css stylesheet
-            f = open(os.path.join(os.path.dirname(__file__), *["htmlfiles", "style.css"]), encoding='utf-8')
-            self.css_styles = f.read().strip()
+            f = open(os.path.join(os.path.dirname(__file__), *["htmlfiles", "style.css"]), "rb")
+            self.css_styles = f.read().decode('utf-8').strip()
             f.flush()
             f.close()
         except Exception as e:

--- a/coverage/html.py
+++ b/coverage/html.py
@@ -99,8 +99,8 @@ class HtmlReporter(Reporter):
             self.not_inline_styles = False
 
             # reading the css stylesheet
-            f = open(os.path.join(os.path.dirname(__file__), *["htmlfiles", "style.css"]))
-            self.css_styles = f.read().decode('utf-8').strip()
+            f = open(os.path.join(os.path.dirname(__file__), *["htmlfiles", "style.css"]), encoding='utf-8')
+            self.css_styles = f.read().strip()
             f.flush()
             f.close()
         except Exception as e:

--- a/coverage/html.py
+++ b/coverage/html.py
@@ -104,6 +104,7 @@ class HtmlReporter(Reporter):
             f.flush()
             f.close()
         except Exception as e:
+            print(e)
             self.inline_styles = False
             self.not_inline_styles = True
             self.css_styles = None


### PR DESCRIPTION
- Printing exception when inlining styles fails.
- Fixing bug 'str' object has no attribute 'decode'
- Updating code that opens styles file so it can work with both Python 2 and 3.